### PR TITLE
chore: Use yaml-rust2 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 clap = "4.1"
-yaml-rust2 = "0.8"
+yaml-rust2 = "0.10"
 ulid = "1.0"
 bytebuffer = "2.1"


### PR DESCRIPTION
This is critical as yaml-rust2 0.10 produces different YAML to yaml-rust2 0.9